### PR TITLE
Replace deprecated function setTimeout

### DIFF
--- a/src/RedisClient.php
+++ b/src/RedisClient.php
@@ -103,7 +103,6 @@ class RedisClient
             case 'getoption':
             case 'auth':
             case 'select':
-            case 'settimeout':
                     return false;
         }
 

--- a/src/RedisStore.php
+++ b/src/RedisStore.php
@@ -347,7 +347,7 @@ class RedisStore implements StoreInterface
         $this->_client->set($key, $data);
 
         if (is_int($this->_timeOut)) {
-            $this->_client->setTimeout($key, $this->_timeOut);
+            $this->_client->expire($key, $this->_timeOut);
         }
 
         $this->_client->close();


### PR DESCRIPTION
SetTimeout function is deprecated in php-redis since 5.0.0.

Replace deprecated function setTimeout with expire.